### PR TITLE
Add GPT-5 model family support to OpenAI provider

### DIFF
--- a/app/providers/openai.py
+++ b/app/providers/openai.py
@@ -76,6 +76,9 @@ class OpenAIProvider(BaseProvider):
         """
         return [
             ('gpt-4o', 'GPT-4o'),
+            ('gpt-5-pro', 'GPT-5 Pro'),
+            ('gpt-5', 'GPT-5'),
+            ('gpt-5-mini', 'GPT-5 Mini'),
             ('o1', 'o1'),
             ('o1-mini', 'o1-mini')
         ]


### PR DESCRIPTION
## Changes

Adds support for three new GPT-5 model variants to the OpenAI provider:

- `gpt-5-pro` - GPT-5 Pro
- `gpt-5` - GPT-5
- `gpt-5-mini` - GPT-5 Mini

These models are now available for selection alongside existing GPT-4o and o1 model families.