### PR TITLE
fix: Add support for structured table rendering in responses

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -206,8 +206,12 @@
             <div class="card-body">
                 {% if response_data._display_schema %}
                     <!-- Auto-detected schema display -->
+                    {# Set all possible variables from display schema #}
                     {% set content = response_data._display_schema.content %}
                     {% set schema_type = response_data._display_schema.schema_type %}
+                    {% set columns = response_data._display_schema.columns %}
+                    {% set rows = response_data._display_schema.rows %}
+                    {% set totals = response_data._display_schema.totals %}
                     {% include response_data._display_schema.template ignore missing %}
                 {% elif response_data.output %}
                     <!-- Fallback: Display raw output -->


### PR DESCRIPTION
Fixed template variable passing for structured/table schema responses. Added columns, rows, and totals variables to support table partial template rendering. This enables proper display of GPT-5 structured responses that return data in tabular format.