### PR TITLE
feat: Add Voice input mode with Coming Soon tooltip

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -56,7 +56,7 @@ class ResponsesAPIForm(FlaskForm):
 
     input_mode = RadioField(
         'Input Mode',
-        choices=[('text', 'Text'), ('image', 'Image')],
+        choices=[('text', 'Text'), ('image', 'Image'), ('voice', 'Voice')],
         default='text',
         render_kw={"class": "btn-group-toggle"}
     )

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -86,8 +86,13 @@
                         <label class="form-label d-block">{{ form.input_mode.label }}</label>
                         {% for subfield in form.input_mode %}
                         <div class="form-check form-check-inline">
+                            {% if subfield.data == 'voice' %}
+                            {{ subfield(class="form-check-input", disabled=true) }}
+                            {{ subfield.label(class="form-check-label text-muted", style="cursor: not-allowed;", data_bs_toggle="tooltip", data_bs_placement="top", title="Coming Soon") }}
+                            {% else %}
                             {{ subfield(class="form-check-input", onchange="toggleInputMode()") }}
                             {{ subfield.label(class="form-check-label") }}
+                            {% endif %}
                         </div>
                         {% endfor %}
                     </div>
@@ -379,6 +384,14 @@
     }
 
     // Initialize toggle state on load
-    document.addEventListener('DOMContentLoaded', toggleInputMode);
+    document.addEventListener('DOMContentLoaded', function() {
+        toggleInputMode();
+
+        // Initialize Bootstrap tooltips
+        const tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
+        tooltipTriggerList.map(function (tooltipTriggerEl) {
+            return new bootstrap.Tooltip(tooltipTriggerEl);
+        });
+    });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Added Voice as a third input mode option alongside Text and Image
- Voice option is currently disabled with a "Coming Soon" tooltip
- Enhanced UI with Bootstrap tooltip support for better user experience

## Changes
- Updated `app/forms.py`: Added 'voice' to input_mode RadioField choices
- Updated `app/templates/index.html`:
  - Added conditional rendering to disable Voice option
  - Added tooltip with "Coming Soon" message
  - Styled disabled state with grayed-out text and not-allowed cursor
  - Initialized Bootstrap tooltips in JavaScript

## Test plan
- [x] Voice option appears in the Input Mode section
- [x] Voice option is disabled and cannot be selected
- [x] Tooltip shows "Coming Soon" on hover
- [x] Text and Image modes continue to work as expected
- [x] UI styling is consistent with existing design

🤖 Generated with [Claude Code](https://claude.com/claude-code)