### PR TITLE
feat: Deploy Flask app to Railway with 1Password Service Account (#10)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+venv/
+__pycache__/
+**/__pycache__/
+.env
+.env.*
+*.DS_Store
+*.pyc
+.git/
+docs/
+tests/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.9-slim
+
+# Install 1Password CLI
+ARG OP_VERSION=2.29.0
+RUN apt-get update && apt-get install -y --no-install-recommends unzip curl && \
+    curl -sSfo op.zip "https://cache.agilebits.com/dist/1P/op2/pkg/v${OP_VERSION}/op_linux_amd64_v${OP_VERSION}.zip" && \
+    unzip -o op.zip op -d /usr/local/bin/ && \
+    rm op.zip && \
+    apt-get purge -y unzip curl && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD gunicorn run:app --bind 0.0.0.0:${PORT:-8000} --workers 2

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,8 @@
+[build]
+builder = "dockerfile"
+
+[deploy]
+healthcheckPath = "/"
+healthcheckTimeout = 30
+restartPolicyType = "on_failure"
+restartPolicyMaxRetries = 3

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Flask-WTF==1.2.1
 WTForms==3.1.1
 python-dotenv==1.0.0
 requests==2.31.0
+gunicorn==21.2.0

--- a/run.py
+++ b/run.py
@@ -5,6 +5,8 @@ Application entry point for AI Sandbox Flask application.
 This script initializes and runs the Flask development server.
 For production deployment, use a WSGI server like Gunicorn instead.
 """
+import os
+
 from app import create_app
 
 # Create the Flask application
@@ -13,7 +15,7 @@ app = create_app()
 if __name__ == '__main__':
     # Run the Flask development server
     app.run(
-        host='127.0.0.1',
-        port=5001,
+        host='0.0.0.0',
+        port=int(os.environ.get('PORT', 5001)),
         debug=app.config.get('DEBUG', True)
     )


### PR DESCRIPTION
## Summary

- Adds `Dockerfile` using `python:3.9-slim` with `op` CLI v2.29.0 installed at build time
- Adds `railway.toml` pointing Railway to the Dockerfile with healthcheck on `/`
- Adds `.dockerignore` to keep the image lean
- Adds `gunicorn==21.2.0` to `requirements.txt` as the production WSGI server
- Updates `run.py` to bind to `0.0.0.0` and respect the `PORT` env var

Secrets flow: Railway holds `OP_SERVICE_ACCOUNT_TOKEN` + `op://` references. The `op` CLI in the container authenticates with the service account and `OnePasswordService.get_secret()` calls `op read` exactly as in local dev — no application code changes.

Local dev via `./start.sh` is unaffected.

Closes #10

## Test plan

- [ ] All 32 existing tests pass (`PYTHONPATH=. pytest tests/`)
- [ ] `railway variables set` all required env vars (see issue #10 for list)
- [ ] `railway up` succeeds and healthcheck on `/` passes
- [ ] App is reachable via Railway public URL
- [ ] Provider dropdown works and an API call succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)