### PR TITLE
feat: replace path inputs with file upload for remote deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ __pycache__/
 instance/
 .webassets-cache
 
+# User uploads (runtime state — never commit user files)
+uploads/
+
 # IDE
 .vscode/
 .idea/

--- a/app/forms.py
+++ b/app/forms.py
@@ -1,6 +1,7 @@
 from flask_wtf import FlaskForm
-from wtforms import StringField, TextAreaField, IntegerField, DecimalField, BooleanField, SelectField, RadioField
-from wtforms.validators import DataRequired, Optional, NumberRange, Length, ValidationError
+from flask_wtf.file import FileField, FileAllowed
+from wtforms import TextAreaField, IntegerField, DecimalField, BooleanField, SelectField, RadioField
+from wtforms.validators import DataRequired, Optional, NumberRange, ValidationError
 from app.providers import list_providers, get_provider_class
 import json
 
@@ -45,13 +46,10 @@ class ResponsesAPIForm(FlaskForm):
         render_kw={"class": "form-select"}
     )
 
-    system_instruction_file = StringField(
-        'System Instruction File Path',
-        validators=[Optional()],
-        render_kw={
-            "placeholder": "/path/to/system-instructions.md",
-            "class": "form-control"
-        }
+    system_instruction_file = FileField(
+        'System Instructions',
+        validators=[Optional(), FileAllowed(['md', 'txt'], 'Markdown or text files only')],
+        render_kw={"class": "form-control", "accept": ".md,.txt"}
     )
 
     input_mode = RadioField(
@@ -61,13 +59,10 @@ class ResponsesAPIForm(FlaskForm):
         render_kw={"class": "btn-group-toggle"}
     )
 
-    image_path = StringField(
-        'Image Path',
-        validators=[Optional()],
-        render_kw={
-            "placeholder": "/absolute/path/to/image.jpg",
-            "class": "form-control"
-        }
+    image_file = FileField(
+        'Image',
+        validators=[Optional(), FileAllowed(['jpg', 'jpeg', 'png', 'gif', 'webp'], 'Images only')],
+        render_kw={"class": "form-control", "accept": "image/*"}
     )
 
     input = TextAreaField(

--- a/app/forms.py
+++ b/app/forms.py
@@ -46,7 +46,7 @@ class ResponsesAPIForm(FlaskForm):
         render_kw={"class": "form-select"}
     )
 
-    system_instruction_file = FileField(
+    system_instruction_upload = FileField(
         'System Instructions',
         validators=[Optional(), FileAllowed(['md', 'txt'], 'Markdown or text files only')],
         render_kw={"class": "form-control", "accept": ".md,.txt"}
@@ -59,7 +59,7 @@ class ResponsesAPIForm(FlaskForm):
         render_kw={"class": "btn-group-toggle"}
     )
 
-    image_file = FileField(
+    image_upload = FileField(
         'Image',
         validators=[Optional(), FileAllowed(['jpg', 'jpeg', 'png', 'gif', 'webp'], 'Images only')],
         render_kw={"class": "form-control", "accept": "image/*"}

--- a/app/routes.py
+++ b/app/routes.py
@@ -4,7 +4,8 @@ import os
 import time
 from datetime import datetime, timezone
 
-from flask import Blueprint, current_app, flash, jsonify, render_template, request, session
+from flask import Blueprint, current_app, flash, jsonify, render_template, request, send_file, session
+from werkzeug.utils import secure_filename
 
 from app.forms import ProviderSelectionForm, ResponsesAPIForm
 from app.providers import get_provider, get_provider_class, list_providers
@@ -15,6 +16,23 @@ from config import Config
 # Create blueprint for routes
 bp = Blueprint("main", __name__)
 logger = logging.getLogger(__name__)
+
+ALLOWED_IMAGE_EXTENSIONS = {"jpg", "jpeg", "png", "gif", "webp"}
+
+
+def _get_upload_folder():
+    folder = current_app.config.get("UPLOAD_FOLDER")
+    os.makedirs(folder, exist_ok=True)
+    return folder
+
+
+def _find_active_image(upload_folder):
+    """Return path to the active image file, or None if none exists."""
+    for ext in ALLOWED_IMAGE_EXTENSIONS:
+        path = os.path.join(upload_folder, f"active_image.{ext}")
+        if os.path.exists(path):
+            return path
+    return None
 
 
 def _format_created_at(created_value):
@@ -91,6 +109,28 @@ def provider_models(name):
     return jsonify([{"value": v, "label": l} for v, l in temp.models])
 
 
+@bp.route("/api/uploads/instructions")
+def preview_instructions():
+    """Return the content of the active system instructions file."""
+    folder = current_app.config.get("UPLOAD_FOLDER", "")
+    path = os.path.join(folder, "active_instructions.md")
+    if not os.path.exists(path):
+        return jsonify({"exists": False, "content": None})
+    with open(path, "r", encoding="utf-8") as f:
+        content = f.read()
+    return jsonify({"exists": True, "content": content})
+
+
+@bp.route("/api/uploads/image")
+def serve_active_image():
+    """Serve the active image file."""
+    folder = current_app.config.get("UPLOAD_FOLDER", "")
+    img_path = _find_active_image(folder)
+    if not img_path:
+        return jsonify({"error": "No active image"}), 404
+    return send_file(img_path)
+
+
 @bp.route("/", methods=["GET", "POST"])
 def index():
     """
@@ -123,51 +163,28 @@ def index():
     # Get available providers for display
     available_providers = list_providers()
 
-    # Pre-populate system instruction file path from session
-    if request.method == "GET" and "system_instruction_file" in session:
-        form.system_instruction_file.data = session["system_instruction_file"]
-
     if form.validate_on_submit():
         try:
-            # Step 1: Handle system instruction file path
+            # Step 1: Handle system instruction file upload
             system_instruction = None
-            if (
-                form.system_instruction_file.data
-                and form.system_instruction_file.data.strip()
-            ):
-                file_path = form.system_instruction_file.data.strip()
+            upload_folder = _get_upload_folder()
+            instr_path = os.path.join(upload_folder, "active_instructions.md")
 
-                # Save the file path to session for persistence
-                session["system_instruction_file"] = file_path
+            uploaded_instr = form.system_instruction_file.data
+            if uploaded_instr and uploaded_instr.filename:
+                uploaded_instr.save(instr_path)
+                logger.info(f"Saved system instruction to: {instr_path}")
 
-                # Read the markdown file
-                if os.path.exists(file_path):
-                    try:
-                        with open(file_path, "r", encoding="utf-8") as f:
-                            system_instruction = f.read()
-                        logger.info(f"Loaded system instruction from: {file_path}")
-                    except Exception as e:
-                        flash(f"Error reading file {file_path}: {str(e)}", "warning")
-                        logger.error(f"Error reading system instruction file: {e}")
-                else:
-                    flash(f"File not found: {file_path}", "warning")
-                    logger.warning(f"System instruction file not found: {file_path}")
-            elif "system_instruction_file" in session:
-                # Use previously saved file path
-                file_path = session["system_instruction_file"]
-                if os.path.exists(file_path):
-                    try:
-                        with open(file_path, "r", encoding="utf-8") as f:
-                            system_instruction = f.read()
-                        logger.info(
-                            f"Loaded system instruction from saved path: {file_path}"
-                        )
-                        # Pre-populate the form field with saved path
-                        form.system_instruction_file.data = file_path
-                    except Exception as e:
-                        logger.error(
-                            f"Error reading saved system instruction file: {e}"
-                        )
+            if os.path.exists(instr_path):
+                try:
+                    with open(instr_path, "r", encoding="utf-8") as f:
+                        system_instruction = f.read()
+                    logger.info(
+                        f"Loaded system instruction ({len(system_instruction)} chars)"
+                    )
+                except Exception as e:
+                    flash(f"Error reading system instructions: {str(e)}", "warning")
+                    logger.error(f"Error reading system instruction file: {e}")
 
             # Step 2: Retrieve API key from 1Password
             # Use the selected provider
@@ -190,15 +207,30 @@ def index():
                 if not form.input.data or not form.input.data.strip():
                     raise ValueError("Input text is required in text mode")
             elif form.input_mode.data == "image":
-                if not form.image_path.data or not form.image_path.data.strip():
-                    raise ValueError("Image path is required in image mode")
+                active_img_path = None
 
-                image_path = form.image_path.data.strip()
-                if not os.path.exists(image_path):
-                    raise ValueError(f"Image file not found at: {image_path}")
+                uploaded_img = form.image_file.data
+                if uploaded_img and uploaded_img.filename:
+                    filename = secure_filename(uploaded_img.filename)
+                    ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else "jpg"
+                    # Remove any previously stored active image
+                    for old_ext in ALLOWED_IMAGE_EXTENSIONS:
+                        old_path = os.path.join(upload_folder, f"active_image.{old_ext}")
+                        if os.path.exists(old_path):
+                            os.remove(old_path)
+                    active_img_path = os.path.join(upload_folder, f"active_image.{ext}")
+                    uploaded_img.save(active_img_path)
+                    logger.info(f"Saved uploaded image to: {active_img_path}")
+                else:
+                    active_img_path = _find_active_image(upload_folder)
 
-                params["image_path"] = image_path
-                logger.info(f"Processing image input: {image_path}")
+                if not active_img_path:
+                    raise ValueError(
+                        "An image is required in Image Mode. Please upload an image."
+                    )
+
+                params["image_path"] = active_img_path
+                logger.info(f"Processing image input: {active_img_path}")
 
             # Add system instruction if available (top-level parameter)
             if system_instruction:
@@ -329,6 +361,17 @@ def index():
             logger.exception(f"{error_type} from {provider_name}: {e}")
             flash(error_message, "danger")
 
+    # Compute active upload file info for the template
+    _upload_folder = current_app.config.get("UPLOAD_FOLDER", "")
+    active_instructions_file = None
+    active_image_file = None
+    if _upload_folder and os.path.isdir(_upload_folder):
+        if os.path.exists(os.path.join(_upload_folder, "active_instructions.md")):
+            active_instructions_file = "active_instructions.md"
+        active_img = _find_active_image(_upload_folder)
+        if active_img:
+            active_image_file = os.path.basename(active_img)
+
     return render_template(
         "index.html",
         form=form,
@@ -337,4 +380,6 @@ def index():
         available_providers=available_providers,
         response_data=response_data,
         error=error_message,
+        active_instructions_file=active_instructions_file,
+        active_image_file=active_image_file,
     )

--- a/app/routes.py
+++ b/app/routes.py
@@ -170,7 +170,7 @@ def index():
             upload_folder = _get_upload_folder()
             instr_path = os.path.join(upload_folder, "active_instructions.md")
 
-            uploaded_instr = form.system_instruction_file.data
+            uploaded_instr = form.system_instruction_upload.data
             if uploaded_instr and uploaded_instr.filename:
                 uploaded_instr.save(instr_path)
                 logger.info(f"Saved system instruction to: {instr_path}")
@@ -209,7 +209,7 @@ def index():
             elif form.input_mode.data == "image":
                 active_img_path = None
 
-                uploaded_img = form.image_file.data
+                uploaded_img = form.image_upload.data
                 if uploaded_img and uploaded_img.filename:
                     filename = secure_filename(uploaded_img.filename)
                     ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else "jpg"

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -39,7 +39,7 @@
 
                     <!-- System Instructions Upload -->
                     <div class="mb-3">
-                        <label class="form-label">{{ form.system_instruction_file.label }}</label>
+                        <label class="form-label">{{ form.system_instruction_upload.label }}</label>
                         {% if active_instructions_file %}
                         <div class="d-flex align-items-center gap-2 mb-2">
                             <span class="badge bg-success">Active</span>
@@ -53,20 +53,20 @@
                                 Replace
                             </button>
                         </div>
-                        <div class="d-none" id="replaceInstructionsInput">
-                            {{ form.system_instruction_file }}
-                            {% if form.system_instruction_file.errors %}
+                        <div id="replaceInstructionsInput" class="{{ 'd-none' if not form.system_instruction_upload.errors else '' }}">
+                            {{ form.system_instruction_upload }}
+                            {% if form.system_instruction_upload.errors %}
                             <div class="invalid-feedback d-block">
-                                {{ form.system_instruction_file.errors[0] }}
+                                {{ form.system_instruction_upload.errors[0] }}
                             </div>
                             {% endif %}
                             <div class="form-text">Upload a new file to replace the active instructions.</div>
                         </div>
                         {% else %}
-                        {{ form.system_instruction_file }}
-                        {% if form.system_instruction_file.errors %}
+                        {{ form.system_instruction_upload }}
+                        {% if form.system_instruction_upload.errors %}
                         <div class="invalid-feedback d-block">
-                            {{ form.system_instruction_file.errors[0] }}
+                            {{ form.system_instruction_upload.errors[0] }}
                         </div>
                         {% endif %}
                         <div class="form-text">Upload a .md or .txt file with system instructions.</div>
@@ -97,7 +97,7 @@
                     <!-- Image Upload (Hidden by default, shown in image mode) -->
                     <div class="mb-3 d-none" id="imageFileGroup">
                         <label class="form-label">
-                            {{ form.image_file.label }}
+                            {{ form.image_upload.label }}
                             <span class="text-danger">*</span>
                         </label>
                         {% if active_image_file %}
@@ -113,15 +113,20 @@
                                 Replace
                             </button>
                         </div>
-                        <div class="d-none" id="replaceImageInput">
-                            {{ form.image_file }}
+                        <div id="replaceImageInput" class="{{ 'd-none' if not form.image_upload.errors else '' }}">
+                            {{ form.image_upload }}
+                            {% if form.image_upload.errors %}
+                            <div class="invalid-feedback d-block">
+                                {{ form.image_upload.errors[0] }}
+                            </div>
+                            {% endif %}
                         </div>
                         {% else %}
-                        {{ form.image_file }}
+                        {{ form.image_upload }}
                         {% endif %}
-                        {% if form.image_file.errors %}
+                        {% if form.image_upload.errors %}
                         <div class="invalid-feedback d-block">
-                            {{ form.image_file.errors[0] }}
+                            {{ form.image_upload.errors[0] }}
                         </div>
                         {% endif %}
                         <div class="form-text">Upload an image (JPG, PNG, GIF, WebP). Required in Image Mode.</div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -10,7 +10,7 @@
         <!-- Combined Form -->
         <div class="card mb-4">
             <div class="card-body">
-                <form method="POST" action="/" id="apiForm">
+                <form method="POST" action="/" id="apiForm" enctype="multipart/form-data">
                     {{ form.hidden_tag() }}
 
                     <!-- Hidden provider field to maintain selection on POST -->
@@ -37,21 +37,40 @@
                         </div>
                     </div>
 
-                    <!-- System Instruction File Path -->
+                    <!-- System Instructions Upload -->
                     <div class="mb-3">
-                        <label for="system_instruction_file" class="form-label">
-                            {{ form.system_instruction_file.label }}
-                        </label>
-                        {{ form.system_instruction_file }} {% if
-                        form.system_instruction_file.errors %}
+                        <label class="form-label">{{ form.system_instruction_file.label }}</label>
+                        {% if active_instructions_file %}
+                        <div class="d-flex align-items-center gap-2 mb-2">
+                            <span class="badge bg-success">Active</span>
+                            <code class="small">{{ active_instructions_file }}</code>
+                            <button type="button" class="btn btn-sm btn-outline-secondary py-0"
+                                    data-bs-toggle="modal" data-bs-target="#instructionsPreviewModal">
+                                Preview
+                            </button>
+                            <button type="button" class="btn btn-sm btn-outline-warning py-0"
+                                    onclick="showReplaceField('replaceInstructionsInput')">
+                                Replace
+                            </button>
+                        </div>
+                        <div class="d-none" id="replaceInstructionsInput">
+                            {{ form.system_instruction_file }}
+                            {% if form.system_instruction_file.errors %}
+                            <div class="invalid-feedback d-block">
+                                {{ form.system_instruction_file.errors[0] }}
+                            </div>
+                            {% endif %}
+                            <div class="form-text">Upload a new file to replace the active instructions.</div>
+                        </div>
+                        {% else %}
+                        {{ form.system_instruction_file }}
+                        {% if form.system_instruction_file.errors %}
                         <div class="invalid-feedback d-block">
                             {{ form.system_instruction_file.errors[0] }}
                         </div>
                         {% endif %}
-                        <div class="form-text">
-                            Path to markdown file with system instructions. Once
-                            set, it will be remembered for future requests.
-                        </div>
+                        <div class="form-text">Upload a .md or .txt file with system instructions.</div>
+                        {% endif %}
                     </div>
 
                     <!-- Input Mode Selection -->
@@ -75,20 +94,37 @@
                         {% endfor %}
                     </div>
 
-                    <!-- Image Path (Hidden by default) -->
-                    <div class="mb-3 d-none" id="imagePathGroup">
-                        <label for="image_path" class="form-label">
-                            {{ form.image_path.label }}
+                    <!-- Image Upload (Hidden by default, shown in image mode) -->
+                    <div class="mb-3 d-none" id="imageFileGroup">
+                        <label class="form-label">
+                            {{ form.image_file.label }}
                             <span class="text-danger">*</span>
                         </label>
-                        {{ form.image_path }} {% if form.image_path.errors %}
+                        {% if active_image_file %}
+                        <div class="d-flex align-items-center gap-2 mb-2">
+                            <span class="badge bg-success">Active</span>
+                            <code class="small">{{ active_image_file }}</code>
+                            <button type="button" class="btn btn-sm btn-outline-secondary py-0"
+                                    data-bs-toggle="modal" data-bs-target="#imagePreviewModal">
+                                Preview
+                            </button>
+                            <button type="button" class="btn btn-sm btn-outline-warning py-0"
+                                    onclick="showReplaceField('replaceImageInput')">
+                                Replace
+                            </button>
+                        </div>
+                        <div class="d-none" id="replaceImageInput">
+                            {{ form.image_file }}
+                        </div>
+                        {% else %}
+                        {{ form.image_file }}
+                        {% endif %}
+                        {% if form.image_file.errors %}
                         <div class="invalid-feedback d-block">
-                            {{ form.image_path.errors[0] }}
+                            {{ form.image_file.errors[0] }}
                         </div>
                         {% endif %}
-                        <div class="form-text">
-                            Enter the absolute path to a local image file.
-                        </div>
+                        <div class="form-text">Upload an image (JPG, PNG, GIF, WebP). Required in Image Mode.</div>
                     </div>
 
                     <!-- Input Text -->
@@ -431,7 +467,41 @@
                 </div>
             </div>
         </div>
-        {% endif %} {% if error %}
+        {% endif %}
+
+        <!-- System Instructions Preview Modal -->
+        <div class="modal fade" id="instructionsPreviewModal" tabindex="-1">
+            <div class="modal-dialog modal-lg">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title">System Instructions Preview</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                    </div>
+                    <div class="modal-body">
+                        <pre id="instructionsPreviewContent"
+                             class="p-3 bg-light rounded"
+                             style="white-space: pre-wrap; max-height: 60vh; overflow-y: auto; font-size: 0.85rem;">Loading...</pre>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Active Image Preview Modal -->
+        <div class="modal fade" id="imagePreviewModal" tabindex="-1">
+            <div class="modal-dialog modal-dialog-centered">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title">Image Preview</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                    </div>
+                    <div class="modal-body text-center p-3">
+                        <img src="/api/uploads/image" class="img-fluid rounded" alt="Active image">
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        {% if error %}
         <div class="card">
             <div class="card-header bg-danger text-white">
                 <h5 class="mb-0">Error</h5>
@@ -462,7 +532,7 @@
             'input[name="input_mode"]:checked',
         ).value;
         const textGroup = document.getElementById("inputTextGroup");
-        const imageGroup = document.getElementById("imagePathGroup");
+        const imageGroup = document.getElementById("imageFileGroup");
 
         if (mode === "image") {
             textGroup.classList.add("d-none");
@@ -471,6 +541,12 @@
             textGroup.classList.remove("d-none");
             imageGroup.classList.add("d-none");
         }
+    }
+
+    // Show a hidden replace-file input
+    function showReplaceField(id) {
+        const el = document.getElementById(id);
+        if (el) el.classList.remove("d-none");
     }
 
     // Update model dropdown when provider selection changes
@@ -503,6 +579,23 @@
         if (providerSelect) {
             providerSelect.addEventListener("change", function () {
                 updateModels(this.value);
+            });
+        }
+
+        // Fetch and display system instructions in preview modal
+        const instrModal = document.getElementById("instructionsPreviewModal");
+        if (instrModal) {
+            instrModal.addEventListener("show.bs.modal", function () {
+                const pre = document.getElementById("instructionsPreviewContent");
+                pre.textContent = "Loading...";
+                fetch("/api/uploads/instructions")
+                    .then((r) => r.json())
+                    .then((data) => {
+                        pre.textContent = data.content || "(empty file)";
+                    })
+                    .catch(() => {
+                        pre.textContent = "Failed to load preview.";
+                    });
             });
         }
     });

--- a/config.py
+++ b/config.py
@@ -5,12 +5,18 @@ from dotenv import load_dotenv
 # Load environment variables from .env file
 load_dotenv()
 
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
 
 class Config:
     """Base configuration with environment variable loading and validation"""
 
     # Required configuration
     SECRET_KEY = os.environ.get("SECRET_KEY") or "dev-secret-key-change-in-production"
+
+    # File uploads
+    UPLOAD_FOLDER = os.environ.get("UPLOAD_FOLDER") or os.path.join(BASE_DIR, "uploads")
+    MAX_CONTENT_LENGTH = 16 * 1024 * 1024  # 16 MB upload limit
 
     # Multi-provider API key references (1Password)
     OP_ITEM_REFERENCE_OPENAI = os.environ.get("OP_ITEM_REFERENCE_OPENAI")

--- a/tests/test_error_visibility.py
+++ b/tests/test_error_visibility.py
@@ -1,0 +1,65 @@
+import os
+import io
+import pytest
+from flask import Flask
+from app.routes import bp
+from config import Config
+
+class TestConfig(Config):
+    TESTING = True
+    WTF_CSRF_ENABLED = False
+    UPLOAD_FOLDER = os.path.join(os.path.dirname(__file__), 'test_uploads_errors')
+    SECRET_KEY = 'test-key'
+
+@pytest.fixture
+def app():
+    base_dir = os.path.dirname(os.path.dirname(__file__))
+    app = Flask(__name__, 
+                template_folder=os.path.join(base_dir, 'app', 'templates'),
+                static_folder=os.path.join(base_dir, 'app', 'static'))
+    app.config.from_object(TestConfig)
+    app.register_blueprint(bp)
+    os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
+    yield app
+    import shutil
+    if os.path.exists(app.config['UPLOAD_FOLDER']):
+        shutil.rmtree(app.config['UPLOAD_FOLDER'])
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+def test_hidden_error_messages(client, app):
+    # 1. Setup an active instructions file so the "Replace" UX is active
+    os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
+    with open(os.path.join(app.config['UPLOAD_FOLDER'], 'active_instructions.md'), 'w') as f:
+        f.write('initial content')
+        
+    # 2. Upload an invalid file type (e.g., .exe)
+    data = {
+        'system_instruction_upload': (io.BytesIO(b'malicious'), 'test.exe'),
+        'input_mode': 'text',
+        'input': 'test prompt',
+        'model': 'gpt-4o',
+        'provider': 'openai'
+    }
+    
+    resp = client.post('/', data=data, content_type='multipart/form-data')
+    html = resp.data.decode()
+    
+    # Check if error message is present
+    assert 'Markdown or text files only' in html
+    
+    # Check if the error message is inside a d-none div
+    # In the current implementation:
+    # <div class="d-none" id="replaceInstructionsInput">
+    #     ...
+    #     <div class="invalid-feedback d-block">Markdown or text files only</div>
+    # </div>
+    
+    import re
+    # The replace div must be visible (no d-none) when there are field errors
+    match = re.search(r'<div id="replaceInstructionsInput" class="([^"]*)">', html)
+    assert match is not None, "replaceInstructionsInput div not found"
+    classes = match.group(1).split()
+    assert 'd-none' not in classes, "replaceInstructionsInput should be visible when there are errors"

--- a/tests/test_file_uploads.py
+++ b/tests/test_file_uploads.py
@@ -37,7 +37,7 @@ def client(app):
 def test_instruction_upload_and_persistence(client, app):
     # 1. Upload a file
     data = {
-        'system_instruction_file': (io.BytesIO(b'Test instructions'), 'test.md'),
+        'system_instruction_upload': (io.BytesIO(b'Test instructions'), 'test.md'),
         'input_mode': 'text',
         'input': 'test prompt',
         'model': 'gpt-4o',
@@ -61,7 +61,7 @@ def test_instruction_upload_and_persistence(client, app):
 def test_image_upload_and_persistence(client, app):
     # 1. Upload an image
     data = {
-        'image_file': (io.BytesIO(b'fake image data'), 'test.png'),
+        'image_upload': (io.BytesIO(b'fake image data'), 'test.png'),
         'input_mode': 'image',
         'input': 'what is this',
         'model': 'gpt-4o',

--- a/tests/test_file_uploads.py
+++ b/tests/test_file_uploads.py
@@ -1,0 +1,96 @@
+import os
+import io
+import pytest
+from flask import Flask, session
+from app.routes import bp
+from config import Config
+
+class TestConfig(Config):
+    TESTING = True
+    WTF_CSRF_ENABLED = False
+    UPLOAD_FOLDER = os.path.join(os.path.dirname(__file__), 'test_uploads')
+    SECRET_KEY = 'test-key'
+
+@pytest.fixture
+def app():
+    base_dir = os.path.dirname(os.path.dirname(__file__))
+    app = Flask(__name__, 
+                template_folder=os.path.join(base_dir, 'app', 'templates'),
+                static_folder=os.path.join(base_dir, 'app', 'static'))
+    app.config.from_object(TestConfig)
+    app.register_blueprint(bp)
+    
+    # Ensure upload folder exists
+    os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
+    
+    yield app
+    
+    # Cleanup upload folder
+    import shutil
+    if os.path.exists(app.config['UPLOAD_FOLDER']):
+        shutil.rmtree(app.config['UPLOAD_FOLDER'])
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+def test_instruction_upload_and_persistence(client, app):
+    # 1. Upload a file
+    data = {
+        'system_instruction_file': (io.BytesIO(b'Test instructions'), 'test.md'),
+        'input_mode': 'text',
+        'input': 'test prompt',
+        'model': 'gpt-4o',
+        'provider': 'openai'
+    }
+    
+    with client:
+        resp = client.post('/', data=data, content_type='multipart/form-data')
+        # If it didn't save, maybe it didn't validate.
+        # We can't easily see form errors here without some tricks, 
+        # but let's check if the file exists first.
+    
+    instr_path = os.path.join(app.config['UPLOAD_FOLDER'], 'active_instructions.md')
+    if not os.path.exists(instr_path):
+        print(f"DEBUG: File not found at {instr_path}")
+        print(resp.data.decode())
+    assert os.path.exists(instr_path)
+    with open(instr_path, 'r') as f:
+        assert f.read() == 'Test instructions'
+
+def test_image_upload_and_persistence(client, app):
+    # 1. Upload an image
+    data = {
+        'image_file': (io.BytesIO(b'fake image data'), 'test.png'),
+        'input_mode': 'image',
+        'input': 'what is this',
+        'model': 'gpt-4o',
+        'provider': 'openai'
+    }
+    
+    with client:
+        client.post('/', data=data, content_type='multipart/form-data')
+    
+    # The extension should be preserved in the name
+    image_path = os.path.join(app.config['UPLOAD_FOLDER'], 'active_image.png')
+    assert os.path.exists(image_path)
+
+def test_preview_endpoints(client, app):
+    # Setup files
+    os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
+    with open(os.path.join(app.config['UPLOAD_FOLDER'], 'active_instructions.md'), 'w') as f:
+        f.write('Active instructions content')
+    
+    with open(os.path.join(app.config['UPLOAD_FOLDER'], 'active_image.jpg'), 'wb') as f:
+        f.write(b'fake jpeg')
+        
+    # Test instruction preview
+    resp = client.get('/api/uploads/instructions')
+    assert resp.status_code == 200
+    assert resp.json['exists'] is True
+    assert resp.json['content'] == 'Active instructions content'
+    
+    # Test image preview
+    resp = client.get('/api/uploads/image')
+    assert resp.status_code == 200
+    assert resp.data == b'fake jpeg'


### PR DESCRIPTION
## Summary

- Replaces `system_instruction_file` (text path input) and `image_path` (text path input) with `FileField` uploads that work in remote deployments
- System instructions are persisted to `uploads/active_instructions.md`; images to `uploads/active_image.<ext>`
- Active files are shown with **Preview** / **Replace** controls and Bootstrap modal previews
- `UPLOAD_FOLDER` env var allows pointing to a Railway persistent volume with no code changes

## Changes

| File | What changed |
|------|-------------|
| `config.py` | `UPLOAD_FOLDER` (env-overridable) + `MAX_CONTENT_LENGTH = 16 MB` |
| `app/forms.py` | `StringField` paths → `FileField` with `FileAllowed` validators |
| `app/routes.py` | File save/read logic; `GET /api/uploads/instructions` + `/api/uploads/image` endpoints; active-file context passed to template |
| `app/templates/index.html` | `multipart/form-data`; upload widgets; active-file indicators; preview modals; updated JS |

## Test plan

- [ ] Upload a `.md` system instructions file — verify it persists across requests and shows "Active" badge
- [ ] Click **Preview** — verify modal shows file content
- [ ] Click **Replace** — verify file input appears and new upload overwrites the old one
- [ ] Switch to Image Mode, upload an image — verify submission works and "Active" badge appears
- [ ] Click image **Preview** — verify thumbnail loads
- [ ] Submit in Image Mode with no image uploaded and no active image — verify error message
- [ ] Set `UPLOAD_FOLDER` env var to a custom path — verify uploads go there

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)